### PR TITLE
Fix sample compose field

### DIFF
--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -10,5 +10,5 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - ./conf.d:/etc/nginx/user.conf.d :ro
+      - ./conf.d:/etc/nginx/user.conf.d:ro
 


### PR DESCRIPTION
Otherwise I ended up with a file with a trailing space (`user.conf.d `)